### PR TITLE
[Bug] Fix removal of unstaged changes on branch change

### DIFF
--- a/src/GToolkit4Git/GtGitAddRepositoryStencil.class.st
+++ b/src/GToolkit4Git/GtGitAddRepositoryStencil.class.st
@@ -58,7 +58,7 @@ GtGitAddRepositoryStencil >> initialPage [
 { #category : #accessing }
 GtGitAddRepositoryStencil >> initializePage [
 	| fileBrowser |
-	fileBrowser := BrFileSelector new margin: (BlInsets all: 5).
+	fileBrowser := BrFileSelector new margin: (BlInsets all: 10).
 
 	fileBrowser vExact: 400.
 	fileBrowser hExact: 464.
@@ -91,13 +91,11 @@ GtGitAddRepositoryStencil >> initializePage [
 
 { #category : #accessing }
 GtGitAddRepositoryStencil >> localPage [
-
 	| fileBrowser |
 	fileBrowser := BrFileSelector new margin: (BlInsets all: 5).
 
 	fileBrowser vExact: 400.
 	fileBrowser hExact: 464.
-	
 
 	fileBrowser buttonLabel: 'Import'.
 	fileBrowser okAction: [ :filePath | 

--- a/src/GToolkit4Git/GtGitRepository.class.st
+++ b/src/GToolkit4Git/GtGitRepository.class.st
@@ -234,7 +234,11 @@ GtGitRepository >> branchDescription [
 		priority: 1;
 		accessor: (MAPluggableAccessor
 				read: [ :aModel | aModel repository branchName ]
-				write: [ :aModel :aValue | aModel repository checkoutBranch: aValue ]);
+				write: [ :aModel :aValue | |repo|
+					repo := aModel repository.
+					(repo branchNamed: aValue
+						ifPresent: [:branch| branch switch ]
+						ifAbsent: [repo createBranch: aValue inCommit: (repo workingCopy referenceCommit)])]);
 		blocCompletion: [ GtStringsCompletionStrategy new
 				completions: self branchNameCompletions ];
 		editorAptitude: [ BrGlamorousRegularEditorAptitude new glamorousFormEditorCodeFontAndSize ];


### PR DESCRIPTION
I came across what I think to be a bug, or at the very least a non obvious interaction when using the git interface.

When a repository has unstaged changes, and we create a new branch, or switch to another branch, all unstaged changes are reverted.

While we can fix this by going into the code changes and reverting, I think the default functionality should be closer to how git normally works, which is that checking out a new branch should not remove unstaged changes, unless a force flag is passed.

This is the default behaviour of the morphic git interface in pharo as well. 

Let me know what you think!