### PR TITLE
Make sure add repository can be used

### DIFF
--- a/src/GToolkit4Git/GtGitAddRepositoryStencil.class.st
+++ b/src/GToolkit4Git/GtGitAddRepositoryStencil.class.st
@@ -61,7 +61,7 @@ GtGitAddRepositoryStencil >> initializePage [
 	fileBrowser := BrFileSelector new margin: (BlInsets all: 5).
 
 	fileBrowser vExact: 400.
-	fileBrowser hExact: 464.
+	fileBrowser hFitContent.
 
 	fileBrowser
 		buttonLabel: 'Initialize';


### PR DESCRIPTION
The path for a new repository can not be edited if the page is fixed size